### PR TITLE
Fixing little syntax mistake causing PHP Warning

### DIFF
--- a/classes/class-wcmp-order.php
+++ b/classes/class-wcmp-order.php
@@ -723,7 +723,7 @@ class WCMp_Order {
 //                                $check += $suborder_statuses[ $status ];
 //                            }
 //                        }
-                        if( count($status == 1) && isset($status[0]) ) {
+                        if( count($status) == 1 && isset($status[0]) ) {
                             $parent_order->update_status( $new_status, _x( "Sync from vendor's suborders: ", 'Order note', 'dc-woocommerce-multi-vendor' ) );
                         }
                     }


### PR DESCRIPTION
[10-Sep-2019 18:42:06 UTC] PHP Warning:  count(): Parameter must be an array or an object that implements Countable in /wp-content/plugins/dc-woocommerce-multi-vendor/classes/class-wcmp-order.php on line 726