### PR TITLE
Add wcmp_get_commission_line_total filter

### DIFF
--- a/classes/class-wcmp-calculate-commission.php
+++ b/classes/class-wcmp-calculate-commission.php
@@ -497,6 +497,10 @@ class WCMp_Calculate_Commission {
         } else {
             $line_total = $order->get_item_subtotal($item, false, false) * $item['qty'];
         }
+
+        // Filter the item total before calculating item commission.
+        $line_total = apply_filters('wcmp_get_commission_line_total', $line_total, $product_id, $variation_id, $item, $order_id, $item_id);
+
         if ($product_id) {
             $vendor_id = wc_get_order_item_meta($item_id, '_vendor_id', true);
             if ($vendor_id) {


### PR DESCRIPTION
Adds the ability to filter line item total before calculating item commission.

The use case for this one: I want to apply a discount (besides WC discount system) when using a specific payment method - this filter allows me to deduce a percentage or fixed fee.

Using default discount code from WC is not an option since user will receive the discount automatically.